### PR TITLE
fix(routerpage): assign metadata change to correct tab (closes #135)

### DIFF
--- a/lib/mixins/routerPage.js
+++ b/lib/mixins/routerPage.js
@@ -29,12 +29,14 @@ export default {
         if (!val) return
 
         const tab = typeof val === 'string' ? { title: val } : val
-        const { activeTab } = this.$tabs || emptyObj
+        const changedTabKey = this.$vnode.data.key
+        const changedTab =
+          this.$tabs.items.find(item => item.id == changedTabKey) || emptyObj
 
-        if (tab && activeTab) {
+        if (tab && changedTab) {
           for (const key in tab) {
             if (!['id', 'to'].includes(key)) {
-              this.$set(activeTab, key, tab[key])
+              this.$set(changedTab, key, tab[key])
             }
           }
         }


### PR DESCRIPTION
When the `routeTab` property of a background tab changed the new metadata was always assigned to the
currently active tab instead.

fix #135