### PR TITLE
fix: 页面实例不存在错误

### DIFF
--- a/lib/mixins/pageLeave.js
+++ b/lib/mixins/pageLeave.js
@@ -62,8 +62,12 @@ export default {
 
       // 未开启缓存时，获取当前页面组件实例
       if (!vm && this.activeTabId === id) {
-        vm = this.$route.matched[this.$alive.routeMatch.routeIndex].instances
-          .default
+        try {
+          vm = this.$route.matched[this.$alive.routeMatch.routeIndex].instances
+            .default
+        } catch (_) {
+          vm = null
+        }
       }
 
       if (!vm || !tab) return


### PR DESCRIPTION
当this.$route.matched[this.$alive.routeMatch.routeIndex]为 undefined 时,访问this.$route.matched[this.$alive.routeMatch.routeIndex].instances.default 会出现语法错误,进而导致`$tabs
      .leavePage(id, type)
      .then(next)
      .catch(() => next(false))`错误被捕获,路由无法跳转